### PR TITLE
Add `--no-runtime-skip` test arg, and use in CI for ensuring podman

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,7 +61,7 @@ jobs:
           pip install --upgrade ${{ matrix.pydantic-version }}
       - name: Run tests
         run: |
-          python -m pytest -vv --durations=10 tests/python_on_whales/components/${{ matrix.component }}
+          python -m pytest -vv --no-runtime-skip --durations=10 tests/python_on_whales/components/${{ matrix.component }}
 
   build-linux-test-other:
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
           ./scripts/ci-setup.sh
       - name: Run tests
         run: |
-          python -m pytest -vv --durations=10 --ignore=tests/python_on_whales/components/
+          python -m pytest -vv --no-runtime-skip --durations=10 --ignore=tests/python_on_whales/components/
 
   build-windows:
     runs-on: windows-latest
@@ -93,7 +93,7 @@ jobs:
           pip install -r tests/test-requirements.txt
       - name: Run single test
         run: |
-          python -m pytest -vv tests/python_on_whales/components/test_volume.py::test_simple_volume
+          python -m pytest -vv --no-runtime-skip -m "not podman" tests/python_on_whales/components/test_volume.py::test_simple_volume
 
 #  cost too much at the moment.
 #  build-macos:
@@ -118,4 +118,4 @@ jobs:
 #          pip install -r tests/test-requirements.txt
 #      - name: Run all tests
 #        run: |
-#          python -m pytest -vv tests/
+#          python -m pytest -vv --no-runtime-skip -m "not podman" tests/

--- a/python_on_whales/test_utils.py
+++ b/python_on_whales/test_utils.py
@@ -4,8 +4,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import List
 
-import pytest
-
 from python_on_whales import client_config
 from python_on_whales.utils import PROJECT_ROOT
 
@@ -27,14 +25,3 @@ def get_all_jsons(object_types: str) -> List[Path]:
         PROJECT_ROOT / "tests/python_on_whales/components/jsons" / object_types
     )
     return sorted(list(jsons_directory.iterdir()), key=lambda x: int(x.stem))
-
-
-DOCKER_TEST_FLAG = "DOCKER_TEST_FLAG"
-PODMAN_TEST_FLAG = "PODMAN_TEST_FLAG"
-
-docker_client = pytest.param(
-    DOCKER_TEST_FLAG, marks=pytest.mark.docker, id="docker client"
-)
-podman_client = pytest.param(
-    PODMAN_TEST_FLAG, marks=pytest.mark.podman, id="podman client"
-)

--- a/scripts/ci-setup.sh
+++ b/scripts/ci-setup.sh
@@ -7,6 +7,7 @@ THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
 "$THIS_DIR"/add-local-docker-registry.sh
 "$THIS_DIR"/download-docker-plugins.sh
 docker info
+podman info
 
 pip install -U pip wheel
 pip install -e ./

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,10 @@ def _get_ctr_client(client_type: str, pytestconfig: pytest.Config) -> DockerClie
             ctr_exe,
             reason,
         )
-        pytest.skip(f"{client_type} unavailable")
+        if pytestconfig.getoption("--no-runtime-skip"):
+            pytest.fail(f"{client_type} unavailable")
+        else:
+            pytest.skip(f"{client_type} unavailable")
 
     return client
 
@@ -140,6 +143,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             help=f"Path to the {name} executable to use in the unit tests."
             f"Defaults to {name}.",
         )
+    pow_group.addoption(
+        "--no-runtime-skip",
+        action="store_true",
+        help="Do not skip tests corresponding to a container runtime that is not available",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:


### PR DESCRIPTION
- Support podman in CI:
  - Add `podman info` output
  - Do not skip tests in CI if docker/podman are not working using new `--no-runtime-skip` CLI arg
  - Deselect podman tests in CI on Windows

Second PR factored out of https://github.com/gabrieldemarmiesse/python-on-whales/pull/525, dependent on https://github.com/gabrieldemarmiesse/python-on-whales/pull/527