### PR TITLE
Fully parameterise tests with `ctr_client` in `test_image.py`

### DIFF
--- a/python_on_whales/test_utils.py
+++ b/python_on_whales/test_utils.py
@@ -4,8 +4,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import List
 
-import pytest
-
 from python_on_whales import client_config
 from python_on_whales.utils import PROJECT_ROOT
 
@@ -27,14 +25,3 @@ def get_all_jsons(object_types: str) -> List[Path]:
         PROJECT_ROOT / "tests/python_on_whales/components/jsons" / object_types
     )
     return sorted(list(jsons_directory.iterdir()), key=lambda x: int(x.stem))
-
-
-DOCKER_TEST_FLAG = "DOCKER_TEST_FLAG"
-PODMAN_TEST_FLAG = "PODMAN_TEST_FLAG"
-
-docker_client = pytest.param(
-    DOCKER_TEST_FLAG, marks=pytest.mark.docker, id="docker client"
-)
-podman_client = pytest.param(
-    PODMAN_TEST_FLAG, marks=pytest.mark.podman, id="podman client"
-)


### PR DESCRIPTION
- Fully parameterise `test_image.py` with podman
  - Some tests updated to support minor differences in podman
  - Other tests marked as xfail for podman for now (note `--runxfail` is useful for bulk fixing xfail tests)
  - Some tests don't make sense to parameterise

Third PR factored out of https://github.com/gabrieldemarmiesse/python-on-whales/pull/525, dependent on https://github.com/gabrieldemarmiesse/python-on-whales/pull/527